### PR TITLE
Fix filtering by location

### DIFF
--- a/src/components/PolicyHolderFilter.js
+++ b/src/components/PolicyHolderFilter.js
@@ -78,7 +78,7 @@ class PolicyHolderFilter extends Component {
                         withNull={true}
                         filters={filters}
                         onChangeFilters={onChangeFilters}
-                        anchor="locations_Uuid"
+                        anchor="parentLocation"
                     />
                 </Grid>
                 <Grid item xs={3} className={classes.item}>

--- a/src/components/PolicyHolderSearcher.js
+++ b/src/components/PolicyHolderSearcher.js
@@ -22,17 +22,6 @@ class PolicyHolderSearcher extends Component {
     }
 
     filtersToQueryParams = (state) => {
-        /**
-         * Location "Level" parameter introduced 
-         * in @see openimis-fe-location_js module 
-         * by @see DetailedLocationFilter component
-         * has to be removed from the filter for backend to respond correctly.
-         * In the future this parameter should be handled to filter
-         * PolicyHolders' locations with parent location
-         */
-        if (state.filters.hasOwnProperty('locations_Uuid')) {
-            state.filters['locations_Uuid']['filter'] = state.filters['locations_Uuid']['filter'].split(',')[0];
-        }
         let prms = Object.keys(state.filters)
             .filter(f => !!state.filters[f]['filter'])
             .map(f => state.filters[f]['filter']);
@@ -60,9 +49,9 @@ class PolicyHolderSearcher extends Component {
             "policyHolder.activityCode",
             "policyHolder.dateValidFrom",
             "policyHolder.dateValidTo",
-            "policyHolder.actionButtonColumnHeader",
-            "policyHolder.actionButtonColumnHeader",
-            "policyHolder.actionButtonColumnHeader"
+            "policyHolder.emptyLabel",
+            "policyHolder.emptyLabel",
+            "policyHolder.emptyLabel"
         ];
     }
 

--- a/src/pickers/ConfigBasedPicker.js
+++ b/src/pickers/ConfigBasedPicker.js
@@ -38,7 +38,7 @@ export class ConfigBasedPicker extends Component {
         return (
             <SelectInput
                 module={module}
-                label={!!disabled ? ' ' : label}
+                label={!!disabled ? 'emptyLabel' : label}
                 options={options}
                 value={value}
                 onChange={this._onChange}

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -34,7 +34,7 @@ function reducer(
                 fetchedPolicyHolders: true,
                 policyHolders: parseData(action.payload.data.policyHolder),
                 policyHoldersPageInfo: pageInfo(action.payload.data.policyHolder),
-                policyHoldersTotalCount: action.payload.data.policyHolder.totalCount,
+                policyHoldersTotalCount: !!action.payload.data.policyHolder ? action.payload.data.policyHolder.totalCount : null,
                 errorPolicyHolders: formatGraphQLError(action.payload)
             };
         case "POLICYHOLDER_POLICYHOLDERS_ERR":

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -14,7 +14,7 @@
     "policyHolder.dateValidTo": "Valid to",
     "policyHolder.isDeleted": "Show deleted",
     "policyHolder.policyHolders.searcher.results.title": "{policyHoldersTotalCount} Policy Holders Found",
-    "policyHolder.actionButtonColumnHeader": " ",
+    "policyHolder.emptyLabel": " ",
     "policyHolder.createNewPolicyHolder.tooltip": "Create new Policy Holder",
     "policyHolder.policyHolder.page.title": "Policy Holder {label}",
     "policyHolder.generalInfoPanel.title": "General Information",


### PR DESCRIPTION
Filtering by location of higher levels was not working properly. As a fix on backend has been implemented, it is now possible to filter PolicyHolders this way.