### PR TITLE
OFS-85: Replace Policy Holder Contribution Plan Bundle

### DIFF
--- a/src/components/PolicyHolderTabPanel.js
+++ b/src/components/PolicyHolderTabPanel.js
@@ -4,7 +4,7 @@ import { withModulesManager, FormPanel, Contributions, decodeId } from "@openimi
 import { injectIntl } from "react-intl";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
-import { fetchPolicyHolderContributionPlanBundles } from "../actions"
+import { fetchPickerPolicyHolderContributionPlanBundles } from "../actions"
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { RIGHT_POLICYHOLDERINSUREE_SEARCH, POLICYHOLDERINSUREE_TAB_VALUE } from "../constants"
 
@@ -40,7 +40,7 @@ class PolicyHolderTabPanel extends FormPanel {
          * @see PolicyHolderInsureesTab and @see PolicyHolderContributionPlanBundlesTab
          */
         if (prevProps.edited !== this.props.edited) {
-            this.props.fetchPolicyHolderContributionPlanBundles(this.props.modulesManager, [`policyHolder_Id: "${decodeId(this.props.edited.id)}"`]);
+            this.props.fetchPickerPolicyHolderContributionPlanBundles(this.props.modulesManager, [`policyHolder_Id: "${decodeId(this.props.edited.id)}"`]);
         }
     }
 
@@ -81,7 +81,7 @@ class PolicyHolderTabPanel extends FormPanel {
 }
 
 const mapDispatchToProps = dispatch => {
-    return bindActionCreators({ fetchPolicyHolderContributionPlanBundles }, dispatch);
+    return bindActionCreators({ fetchPickerPolicyHolderContributionPlanBundles }, dispatch);
 };
 
 export default withModulesManager(injectIntl(withTheme(withStyles(styles)(connect(null, mapDispatchToProps)(PolicyHolderTabPanel)))));

--- a/src/dialogs/UpdatePolicyHolderContributionPlanBundleDialog.js
+++ b/src/dialogs/UpdatePolicyHolderContributionPlanBundleDialog.js
@@ -5,14 +5,14 @@ import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import EditIcon from '@material-ui/icons/Edit';
+import NoteAddIcon from '@material-ui/icons/NoteAdd';
 import { FormattedMessage, formatMessageWithValues, PublishedComponent, formatMessage } from "@openimis/fe-core";
 import { Grid, Tooltip, IconButton } from "@material-ui/core";
 import { withTheme, withStyles } from "@material-ui/core/styles";
-import { updatePolicyHolderContributionPlanBundle } from "../actions";
+import { updatePolicyHolderContributionPlanBundle, replacePolicyHolderContributionPlanBundle } from "../actions";
 import { injectIntl } from 'react-intl';
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
-import PolicyHolderContributionPlanBundlePicker from '../pickers/PolicyHolderContributionPlanBundlePicker';
 
 const styles = theme => ({
     item: theme.paper.item
@@ -39,19 +39,36 @@ class UpdatePolicyHolderContributionPlanBundleDialog extends Component {
     };
 
     handleSave = () => {
-        this.props.updatePolicyHolderContributionPlanBundle(
-            this.state.policyHolderContributionPlanBundle,
-            formatMessageWithValues(
-                this.props.intl,
-                "policyHolder",
-                "UpdatePolicyHolderContributionPlanBundle.mutationLabel",
-                {
-                    code: this.props.policyHolder.code,
-                    tradeName: this.props.policyHolder.tradeName
-                }
-            )
-        );
-        this.props.onSave();
+        const { intl, policyHolder, isReplacing = false, onSave,
+            updatePolicyHolderContributionPlanBundle, replacePolicyHolderContributionPlanBundle } = this.props;
+        if (isReplacing) {
+            replacePolicyHolderContributionPlanBundle(
+                this.state.policyHolderContributionPlanBundle,
+                formatMessageWithValues(
+                    intl,
+                    "policyHolder",
+                    "ReplacePolicyHolderContributionPlanBundle.mutationLabel",
+                    {
+                        code: policyHolder.code,
+                        tradeName: policyHolder.tradeName
+                    }
+                )
+            );
+        } else {
+            updatePolicyHolderContributionPlanBundle(
+                this.state.policyHolderContributionPlanBundle,
+                formatMessageWithValues(
+                    intl,
+                    "policyHolder",
+                    "UpdatePolicyHolderContributionPlanBundle.mutationLabel",
+                    {
+                        code: policyHolder.code,
+                        tradeName: policyHolder.tradeName
+                    }
+                )
+            );
+        }
+        onSave();
         this.handleClose();
     };
 
@@ -72,29 +89,48 @@ class UpdatePolicyHolderContributionPlanBundleDialog extends Component {
     }
 
     render() {
-        const { intl, classes } = this.props;
+        const { intl, classes, disabled, isReplacing = false } = this.props;
         const { open, policyHolderContributionPlanBundle } = this.state;
         return (
             <Fragment>
-                <Tooltip title={formatMessage(intl, "policyHolder", "editButton.tooltip")}>
-                    <div>
-                        <IconButton
-                            onClick={this.handleOpen}>
-                            <EditIcon />
-                        </IconButton>
-                    </div>
-                </Tooltip>
+                {isReplacing ? (
+                    <Tooltip title={formatMessage(intl, "policyHolder", "replaceButton.tooltip")}>
+                        <div>
+                            <IconButton
+                                onClick={this.handleOpen}
+                                disabled={disabled}>
+                                <NoteAddIcon />
+                            </IconButton>
+                        </div>
+                    </Tooltip>
+                ) : (
+                    <Tooltip title={formatMessage(intl, "policyHolder", "editButton.tooltip")}>
+                        <div>
+                            <IconButton
+                                onClick={this.handleOpen}
+                                disabled={disabled}>
+                                <EditIcon />
+                            </IconButton>
+                        </div>
+                    </Tooltip>
+                )}
                 <Dialog open={open} onClose={this.handleClose}>
                     <DialogTitle>
-                        <FormattedMessage module="policyHolder" id="policyHolderContributionPlanBundle.editDialog.title" />
+                        {isReplacing ? (
+                            <FormattedMessage module="policyHolder" id="policyHolderContributionPlanBundle.replaceDialog.title" />
+                        ) : (
+                            <FormattedMessage module="policyHolder" id="policyHolderContributionPlanBundle.editDialog.title" />
+                        )}
                     </DialogTitle>
                     <DialogContent>
                         <Grid container direction="column" className={classes.item}>
                             <Grid item className={classes.item}>
-                                <PolicyHolderContributionPlanBundlePicker
+                                <PublishedComponent
+                                    pubRef="contributionPlan.ContributionPlanBundlePicker"
                                     required
                                     value={!!policyHolderContributionPlanBundle.contributionPlanBundle && policyHolderContributionPlanBundle.contributionPlanBundle}
-                                    readOnly
+                                    onChange={v => this.updateAttribute('contributionPlanBundle', v)}
+                                    readOnly={!isReplacing}
                                 />
                             </Grid>
                             <Grid item className={classes.item}>
@@ -104,7 +140,8 @@ class UpdatePolicyHolderContributionPlanBundleDialog extends Component {
                                     label="dateValidFrom"
                                     required
                                     value={!!policyHolderContributionPlanBundle.dateValidFrom && policyHolderContributionPlanBundle.dateValidFrom}
-                                    readOnly
+                                    onChange={v => this.updateAttribute('dateValidFrom', v)}
+                                    readOnly={!isReplacing}
                                 />
                             </Grid>
                             <Grid item className={classes.item}>
@@ -123,7 +160,11 @@ class UpdatePolicyHolderContributionPlanBundleDialog extends Component {
                             <FormattedMessage module="policyHolder" id="dialog.cancel" />
                         </Button>
                         <Button onClick={this.handleSave} disabled={!this.canSave()} variant="contained" color="primary" autoFocus>
-                            <FormattedMessage module="policyHolder" id="dialog.update" />
+                            {isReplacing ? (
+                                <FormattedMessage module="policyHolder" id="dialog.replace" />
+                            ) : (
+                                <FormattedMessage module="policyHolder" id="dialog.update" />
+                            )}
                         </Button>
                     </DialogActions>
                 </Dialog>
@@ -133,7 +174,7 @@ class UpdatePolicyHolderContributionPlanBundleDialog extends Component {
 }
 
 const mapDispatchToProps = dispatch => {
-    return bindActionCreators({ updatePolicyHolderContributionPlanBundle }, dispatch);
+    return bindActionCreators({ updatePolicyHolderContributionPlanBundle, replacePolicyHolderContributionPlanBundle }, dispatch);
 };
 
 export default injectIntl(withTheme(withStyles(styles)(connect(null, mapDispatchToProps)(UpdatePolicyHolderContributionPlanBundleDialog))));

--- a/src/dialogs/UpdatePolicyHolderInsureeDialog.js
+++ b/src/dialogs/UpdatePolicyHolderInsureeDialog.js
@@ -40,7 +40,7 @@ class UpdatePolicyHolderInsureeDialog extends Component {
     };
 
     handleSave = () => {
-        const { intl, policyHolder, isReplacing = false,
+        const { intl, policyHolder, isReplacing = false, onSave,
             updatePolicyHolderInsuree, replacePolicyHolderInsuree } = this.props;
         if (isReplacing) {
             replacePolicyHolderInsuree(
@@ -69,7 +69,7 @@ class UpdatePolicyHolderInsureeDialog extends Component {
                 )
             );
         }
-        this.props.onSave();
+        onSave();
         this.handleClose();
     };
 
@@ -169,7 +169,7 @@ class UpdatePolicyHolderInsureeDialog extends Component {
                         </Button>
                         <Button onClick={this.handleSave} disabled={!this.canSave()} variant="contained" color="primary" autoFocus>
                             {isReplacing ? (
-                                <FormattedMessage module="policyHolder" id="policyHolderInsuree.dialog.replace" />
+                                <FormattedMessage module="policyHolder" id="dialog.replace" />
                             ) : (
                                 <FormattedMessage module="policyHolder" id="dialog.update" />
                             )}

--- a/src/pickers/PolicyHolderContributionPlanBundlePicker.js
+++ b/src/pickers/PolicyHolderContributionPlanBundlePicker.js
@@ -1,38 +1,17 @@
 import React, { Component } from "react";
 import { withModulesManager, FormattedMessage, SelectInput } from "@openimis/fe-core";
 import { connect } from "react-redux";
+import _ from "lodash";
 
 class PolicyHolderContributionPlanBundlePicker extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            policyHolderContributionPlanBundles: []
-        }
-    }
-
-    componentDidMount() {
-        this.setState((_, props) => ({ policyHolderContributionPlanBundles: props.policyHolderContributionPlanBundles }));
-    }
-
-    componentDidUpdate() {
-        /**
-         * When Policy Holder Contribution Plan Bundle entities are filtered, they are refetched and
-         * the number of options provided to @see PolicyHolderContributionPlanBundlePicker changes.
-         * In order to have all Policy Holder Contribution Plan Bundle entities in the picker,
-         * the biggest number of entities fetched will be provided to the picker as its options.
-         */
-        if (this.props.policyHolderContributionPlanBundles.length > this.state.policyHolderContributionPlanBundles.length) {
-            this.setState((_, props) => ({ policyHolderContributionPlanBundles: props.policyHolderContributionPlanBundles }));
-        }
-    }
-
     render() {
-        const { value, onChange, required = false, withNull = false, nullLabel = null, withLabel = true, readOnly = false } = this.props;
-        const { policyHolderContributionPlanBundles } = this.state;
+        const { value, onChange, required = false, withNull = false, nullLabel = null,
+            withLabel = true, readOnly = false, pickerPolicyHolderContributionPlanBundles } = this.props;
+        let distinctContributionPlanBundles = _.uniqWith(pickerPolicyHolderContributionPlanBundles.map(v => v.contributionPlanBundle), _.isEqual);
         let options = [
-            ...policyHolderContributionPlanBundles.map(v => ({
-                value: v.contributionPlanBundle,
-                label: `${v.contributionPlanBundle.code} - ${v.contributionPlanBundle.name}`
+            ...distinctContributionPlanBundles.map(v => ({
+                value: v,
+                label: `${v.code} - ${v.name}`
             }))
         ];
         if (withNull) {
@@ -56,7 +35,7 @@ class PolicyHolderContributionPlanBundlePicker extends Component {
 }
 
 const mapStateToProps = state => ({
-    policyHolderContributionPlanBundles: state.policyHolder.policyHolderContributionPlanBundles
+    pickerPolicyHolderContributionPlanBundles: state.policyHolder.pickerPolicyHolderContributionPlanBundles
 });
 
 export default withModulesManager(connect(mapStateToProps, null)(PolicyHolderContributionPlanBundlePicker));

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -28,7 +28,13 @@ function reducer(
         fetchedPolicyHolderContributionPlanBundles: false,
         policyHolderContributionPlanBundles: [],
         policyHolderContributionPlanBundlesPageInfo: {},
-        policyHolderContributionPlanBundlesTotalCount: 0
+        policyHolderContributionPlanBundlesTotalCount: 0,
+        fetchingPickerPolicyHolderContributionPlanBundles: false,
+        errorPickerPolicyHolderContributionPlanBundles: null,
+        fetchedPickerPolicyHolderContributionPlanBundles: false,
+        pickerPolicyHolderContributionPlanBundles: [],
+        pickerPolicyHolderContributionPlanBundlesPageInfo: {},
+        pickerPolicyHolderContributionPlanBundlesTotalCount: 0
     },
     action
 ) {
@@ -134,6 +140,32 @@ function reducer(
                 fetchingPolicyHolderContributionPlanBundles: false,
                 errorPolicyHolderContributionPlanBundles: formatServerError(action.payload)
             };
+        case "POLICYHOLDER_PICKERPOLICYHOLDERCONTRIBUTIONPLANBUNDLES_REQ":
+            return {
+                ...state,
+                fetchingPickerPolicyHolderContributionPlanBundles: true,
+                fetchedPickerPolicyHolderContributionPlanBundles: false,
+                pickerPolicyHolderContributionPlanBundles: [],
+                pickerPolicyHolderContributionPlanBundlesPageInfo: {},
+                pickerPolicyHolderContributionPlanBundlesTotalCount: 0,
+                errorPickerPolicyHolderContributionPlanBundles: null
+            };
+        case "POLICYHOLDER_PICKERPOLICYHOLDERCONTRIBUTIONPLANBUNDLES_RESP":
+            return {
+                ...state,
+                fetchingPickerPolicyHolderContributionPlanBundles: false,
+                fetchedPickerPolicyHolderContributionPlanBundles: true,
+                pickerPolicyHolderContributionPlanBundles: parseData(action.payload.data.policyHolderContributionPlanBundle),
+                pickerPolicyHolderContributionPlanBundlesPageInfo: pageInfo(action.payload.data.policyHolderContributionPlanBundle),
+                pickerPolicyHolderContributionPlanBundlesTotalCount: !!action.payload.data.policyHolderContributionPlanBundle ? action.payload.data.policyHolderContributionPlanBundle.totalCount : null,
+                errorPickerPolicyHolderContributionPlanBundles: formatGraphQLError(action.payload)
+            };
+        case "POLICYHOLDER_PICKERPOLICYHOLDERCONTRIBUTIONPLANBUNDLES_ERR":
+            return {
+                ...state,
+                fetchingPickerPolicyHolderContributionPlanBundles: false,
+                errorPickerPolicyHolderContributionPlanBundles: formatServerError(action.payload)
+            };
         case "POLICYHOLDER_MUTATION_REQ":
             return dispatchMutationReq(state, action);
         case "POLICYHOLDER_MUTATION_ERR":
@@ -156,6 +188,8 @@ function reducer(
             return dispatchMutationResp(state, "createPolicyHolderContributionPlanBundle", action);
         case "POLICYHOLDER_UPDATE_POLICYHOLDERCONTRIBUTIONPLANBUNDLE_RESP":
             return dispatchMutationResp(state, "updatePolicyHolderContributionPlanBundle", action);
+        case "POLICYHOLDER_REPLACE_POLICYHOLDERCONTRIBUTIONPLANBUNDLE_RESP":
+            return dispatchMutationResp(state, "replacePolicyHolderContributionPlanBundle", action);
         default:
             return state;
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -63,7 +63,7 @@
     "policyHolder.dialog.cancel": "Cancel",
     "policyHolder.dialog.create": "Create",
     "policyHolder.dialog.update": "Save",
-    "policyHolder.policyHolderInsuree.dialog.replace": "Add",
+    "policyHolder.dialog.replace": "Add",
     "policyHolder.CreatePolicyHolderInsuree.mutationLabel": "Create Policy Holder Insuree for {code} - {tradeName}",
     "policyHolder.UpdatePolicyHolderInsuree.mutationLabel": "Update Policy Holder Insuree of {code} - {tradeName}",
     "policyHolder.DeletePolicyHolderInsuree.mutationLabel": "Delete Policy Holder Insuree from {code} - {tradeName}",
@@ -74,5 +74,7 @@
     "policyHolder.policyHolderContributionPlanBundle.createPolicyHolderContributionPlanBundle": "Create new Contribution Plan Bundle",
     "policyHolder.CreatePolicyHolderContributionPlanBundle.mutationLabel": "Create Contribution Plan Bundle for {code} - {tradeName}",
     "policyHolder.UpdatePolicyHolderContributionPlanBundle.mutationLabel": "Update Contribution Plan Bundle of {code} - {tradeName}",
-    "policyHolder.policyHolderContributionPlanBundle.editDialog.title": "Edit Contribution Plan Bundle"
+    "policyHolder.ReplacePolicyHolderContributionPlanBundle.mutationLabel": "Replace Contribution Plan Bundle of {code} - {tradeName}",
+    "policyHolder.policyHolderContributionPlanBundle.editDialog.title": "Edit Contribution Plan Bundle",
+    "policyHolder.policyHolderContributionPlanBundle.replaceDialog.title": "Add new version of Contribution Plan Bundle"
 }


### PR DESCRIPTION
@delcroip @sniedzielski these changes are pushed regardless of an existing issue - Contribution Plan Bundles (CPBs) as well as Policy Holder Contribution Plan Bundles (PHCPBs) are filtered by default so that only valid entities are returned. This results in both CPB picker (used for displaying CPB in the PHCPB table, creating/updating/replacing PHCPB) and PHCPB picker (used for filtering PH Insurres and PHCPBs, creating PH Insurees) missing invalid entities. What needs to be done to fix this issue is to enable fetching both CPB and PHCPB entities without filtering them by default.