### PR TITLE
OFS-85: Prevent fetching Contribution Plan Bundles for a new Policy Holder

### DIFF
--- a/src/components/PolicyHolderTabPanel.js
+++ b/src/components/PolicyHolderTabPanel.js
@@ -39,7 +39,7 @@ class PolicyHolderTabPanel extends FormPanel {
          * at this point is necessary as they are shared by two tabs:
          * @see PolicyHolderInsureesTab and @see PolicyHolderContributionPlanBundlesTab
          */
-        if (prevProps.edited !== this.props.edited) {
+        if (prevProps.edited !== this.props.edited && !!this.props.edited.id) {
             this.props.fetchPickerPolicyHolderContributionPlanBundles(this.props.modulesManager, [`policyHolder_Id: "${decodeId(this.props.edited.id)}"`]);
         }
     }


### PR DESCRIPTION
When creating a new Policy Holder, an incorrect statement causes fetching Policy Holder Contribution Plan Bundles of a non-existing Policy Holder. This pull request fixes this issue.