### PR TITLE
OFS-182: Fetch Policy Holders for Policy Holder picker

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -8,6 +8,10 @@ const POLICYHOLDER_FULL_PROJECTION = modulesManager => [
     "accountancyAccount", "bankAccount", "paymentReference", "dateValidFrom", "dateValidTo", "isDeleted"
 ];
 
+const POLICYHOLDER_PICKER_PROJECTION = () => [
+    "id", "code", "tradeName"
+];
+
 const POLICYHOLDERINSUREE_FULL_PROJECTION = modulesManager => [
     "id", "dateValidFrom", "dateValidTo", "jsonExt",
     "policyHolder{id}",
@@ -31,6 +35,15 @@ export function fetchPolicyHolders(modulesManager, params) {
         "policyHolder",
         params,
         POLICYHOLDER_FULL_PROJECTION(modulesManager)
+    );
+    return graphql(payload, "POLICYHOLDER_POLICYHOLDERS");
+}
+
+export function fetchPickerPolicyHolders(params) {
+    const payload = formatPageQuery(
+        "policyHolder",
+        params,
+        POLICYHOLDER_PICKER_PROJECTION()
     );
     return graphql(payload, "POLICYHOLDER_POLICYHOLDERS");
 }

--- a/src/pickers/PolicyHolderPicker.js
+++ b/src/pickers/PolicyHolderPicker.js
@@ -1,13 +1,13 @@
 import React, { Component } from "react";
-import { withModulesManager, FormattedMessage, SelectInput } from "@openimis/fe-core";
+import { FormattedMessage, SelectInput } from "@openimis/fe-core";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
-import { fetchPolicyHolders } from "../actions"
+import { fetchPickerPolicyHolders } from "../actions"
 
 class PolicyHolderPicker extends Component {
     componentDidMount() {
         const { withDeleted = false } = this.props;
-        this.props.fetchPolicyHolders(this.props.modulesManager, withDeleted ? [] : ["isDeleted: false"]);
+        this.props.fetchPickerPolicyHolders(withDeleted ? [] : ["isDeleted: false"]);
     }
 
     render() {
@@ -44,7 +44,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => {
-    return bindActionCreators({ fetchPolicyHolders }, dispatch);
+    return bindActionCreators({ fetchPickerPolicyHolders }, dispatch);
 };
 
-export default withModulesManager(connect(mapStateToProps, mapDispatchToProps)(PolicyHolderPicker));
+export default connect(mapStateToProps, mapDispatchToProps)(PolicyHolderPicker);


### PR DESCRIPTION
Policy Holder picker has to use the same projection as specified in `index.js` so that when reused, the value will be correctly loaded into the picker.