### PR TITLE
OFS-180: Fix PHCPB and PH Insurees remaining in pickers when PH is null

### DIFF
--- a/src/components/PolicyHolderContributionPlanBundleFilter.js
+++ b/src/components/PolicyHolderContributionPlanBundleFilter.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react"
 import { injectIntl } from 'react-intl';
+import { connect } from "react-redux";
 import { withModulesManager, formatMessage, PublishedComponent, decodeId } from "@openimis/fe-core";
 import { Grid, FormControlLabel, Checkbox } from "@material-ui/core";
 import { withTheme, withStyles } from "@material-ui/core/styles";
@@ -42,7 +43,7 @@ class PolicyHolderContributionPlanBundleFilter extends Component {
     }
 
     render() {
-        const { intl, classes, onChangeFilters } = this.props;
+        const { intl, classes, onChangeFilters, policyHolder } = this.props;
         return (
             <Grid container className={classes.form}>
                 <Grid item xs={3} className={classes.item}>
@@ -50,6 +51,7 @@ class PolicyHolderContributionPlanBundleFilter extends Component {
                         withNull={true}
                         nullLabel={formatMessage(intl, "policyHolder", "policyHolderContributionPlanBundle.any")}
                         value={this._filterValue('contributionPlanBundle_Id')}
+                        policyHolderId={!!policyHolder && decodeId(policyHolder.id)}
                         onChange={v => onChangeFilters([{
                             id: 'contributionPlanBundle_Id',
                             value: v,
@@ -90,4 +92,8 @@ class PolicyHolderContributionPlanBundleFilter extends Component {
     }
 }
 
-export default withModulesManager(injectIntl(withTheme(withStyles(styles)(PolicyHolderContributionPlanBundleFilter))));
+const mapStateToProps = state => ({
+    policyHolder: !!state.policyHolder.policyHolder ? state.policyHolder.policyHolder : null
+});
+
+export default withModulesManager(injectIntl(withTheme(withStyles(styles)(connect(mapStateToProps, null)(PolicyHolderContributionPlanBundleFilter)))));

--- a/src/components/PolicyHolderInsureeFilter.js
+++ b/src/components/PolicyHolderInsureeFilter.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react"
 import { injectIntl } from 'react-intl';
+import { connect } from "react-redux";
 import { withModulesManager, formatMessage, TextInput, PublishedComponent, decodeId } from "@openimis/fe-core";
 import { Grid, FormControlLabel, Checkbox } from "@material-ui/core";
 import { withTheme, withStyles } from "@material-ui/core/styles";
@@ -52,7 +53,7 @@ class PolicyHolderInsureeFilter extends Component {
     }
 
     render() {
-        const { intl, classes, filters, onChangeFilters } = this.props;
+        const { intl, classes, onChangeFilters, policyHolder } = this.props;
         return (
             <Grid container className={classes.form}>
                 <Grid item xs={3} className={classes.item}>
@@ -67,7 +68,7 @@ class PolicyHolderInsureeFilter extends Component {
                     <PolicyHolderContributionPlanBundlePicker
                         withNull
                         nullLabel={formatMessage(intl, "policyHolder", "policyHolderContributionPlanBundle.any")}
-                        policyHolderId={!!filters['policyHolder_Id'] && filters['policyHolder_Id'].value}
+                        policyHolderId={!!policyHolder && decodeId(policyHolder.id)}
                         value={this._filterValue('contributionPlanBundle_Id')}
                         onChange={v => onChangeFilters([{
                             id: 'contributionPlanBundle_Id',
@@ -109,4 +110,8 @@ class PolicyHolderInsureeFilter extends Component {
     }
 }
 
-export default withModulesManager(injectIntl(withTheme(withStyles(styles)(PolicyHolderInsureeFilter))));
+const mapStateToProps = state => ({
+    policyHolder: !!state.policyHolder.policyHolder ? state.policyHolder.policyHolder : null
+});
+
+export default withModulesManager(injectIntl(withTheme(withStyles(styles)(connect(mapStateToProps, null)(PolicyHolderInsureeFilter)))));

--- a/src/components/PolicyHolderInsureeSearcher.js
+++ b/src/components/PolicyHolderInsureeSearcher.js
@@ -208,11 +208,10 @@ class PolicyHolderInsureeSearcher extends Component {
     }
 
     defaultFilters = () => {
-        const { policyHolder } = this.props;
         return {
             policyHolder_Id: {
-                value: decodeId(policyHolder.id),
-                filter: `policyHolder_Id: "${decodeId(policyHolder.id)}"`
+                value: decodeId(this.props.policyHolder.id),
+                filter: `policyHolder_Id: "${decodeId(this.props.policyHolder.id)}"`
             }
         };
     }

--- a/src/dialogs/CreatePolicyHolderInsureeDialog.js
+++ b/src/dialogs/CreatePolicyHolderInsureeDialog.js
@@ -5,7 +5,7 @@ import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import AddIcon from '@material-ui/icons/Add';
-import { FormattedMessage, formatMessageWithValues, PublishedComponent } from "@openimis/fe-core";
+import { FormattedMessage, formatMessageWithValues, PublishedComponent, decodeId } from "@openimis/fe-core";
 import { Fab, Grid } from "@material-ui/core";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { createPolicyHolderInsuree } from "../actions";
@@ -103,6 +103,7 @@ class CreatePolicyHolderInsureeDialog extends Component {
                                 <PolicyHolderContributionPlanBundlePicker
                                     withNull={true}
                                     required
+                                    policyHolderId={!!policyHolderInsuree.policyHolder && decodeId(policyHolderInsuree.policyHolder.id)}
                                     value={!!policyHolderInsuree.contributionPlanBundle && policyHolderInsuree.contributionPlanBundle}
                                     onChange={v => this.updateAttribute('contributionPlanBundle', v)}
                                 />

--- a/src/dialogs/UpdatePolicyHolderInsureeDialog.js
+++ b/src/dialogs/UpdatePolicyHolderInsureeDialog.js
@@ -6,7 +6,7 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import EditIcon from '@material-ui/icons/Edit';
 import NoteAddIcon from '@material-ui/icons/NoteAdd';
-import { FormattedMessage, formatMessage, formatMessageWithValues, PublishedComponent } from "@openimis/fe-core";
+import { FormattedMessage, formatMessage, formatMessageWithValues, PublishedComponent, decodeId } from "@openimis/fe-core";
 import { Tooltip, Grid, IconButton } from "@material-ui/core";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { updatePolicyHolderInsuree, replacePolicyHolderInsuree } from "../actions";
@@ -136,6 +136,7 @@ class UpdatePolicyHolderInsureeDialog extends Component {
                             <Grid item className={classes.item}>
                                 <PolicyHolderContributionPlanBundlePicker
                                     required
+                                    policyHolderId={!!policyHolderInsuree.policyHolder && decodeId(policyHolderInsuree.policyHolder.id)}
                                     value={!!policyHolderInsuree.contributionPlanBundle && policyHolderInsuree.contributionPlanBundle}
                                     onChange={v => this.updateAttribute('contributionPlanBundle', v)}
                                     readOnly={!isReplacing}

--- a/src/pickers/PolicyHolderContributionPlanBundlePicker.js
+++ b/src/pickers/PolicyHolderContributionPlanBundlePicker.js
@@ -19,15 +19,15 @@ class PolicyHolderContributionPlanBundlePicker extends Component {
     }
 
     render() {
-        const { value, onChange, required = false, withNull = false, nullLabel = null,
-            withLabel = true, readOnly = false, pickerPolicyHolderContributionPlanBundles } = this.props;
+        const { value, onChange, required = false, withNull = false, nullLabel = null, withLabel = true,
+            readOnly = false, policyHolderId, pickerPolicyHolderContributionPlanBundles } = this.props;
         let distinctContributionPlanBundles = _.uniqWith(pickerPolicyHolderContributionPlanBundles.map(v => v.contributionPlanBundle), _.isEqual);
-        let options = [
+        let options = !!policyHolderId ? [
             ...distinctContributionPlanBundles.map(v => ({
                 value: v,
                 label: `${v.code} - ${v.name}`
             }))
-        ];
+        ] : [];
         if (withNull) {
             options.unshift({
                 value: null,

--- a/src/pickers/PolicyHolderInsureePicker.js
+++ b/src/pickers/PolicyHolderInsureePicker.js
@@ -28,13 +28,13 @@ class PolicyHolderInsureePicker extends Component {
 
     render() {
         const { value, onChange, required = false, withNull = false, nullLabel = null,
-            withLabel = true, readOnly = false, pickerPolicyHolderInsurees } = this.props;
-        let options = [
+            withLabel = true, readOnly = false, policyHolderId, pickerPolicyHolderInsurees } = this.props;
+        let options = !!policyHolderId ? [
             ...pickerPolicyHolderInsurees.map(v => ({
                 value: v.insuree,
                 label: `${v.insuree.lastName} ${v.insuree.otherNames}`
             }))
-        ];
+        ] : [];
         if (withNull) {
             options.unshift({
                 value: null,


### PR DESCRIPTION
`PolicyHolderInsureePicker` and `PolicyHolderContributionPlanBundlePicker` should display entities of a corresponding Policy Holder. If Policy Holder is not defined, both pickers should not display any options. When accessing Policy Holder update page, data for both pickers is fetched. However, once a new Policy Holder is created, pickers' data fetched previously remains in `state`. This pull request fixes this incorrect behavior.