### PR TITLE
OFS-270: Update permissions to Policy Holder User search page

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import LegalFormPicker from "./pickers/LegalFormPicker";
 import ActivityCodePicker from "./pickers/ActivityCodePicker";
 import reducer from "./reducer";
 import {
+    RIGHT_POLICYHOLDERUSER_SEARCH,
     RIGHT_POLICYHOLDER_SEARCH,
     RIGHT_PORTALPOLICYHOLDERUSER_SEARCH,
     RIGHT_PORTALPOLICYHOLDER_SEARCH
@@ -96,7 +97,11 @@ const DEFAULT_CONFIG = {
             ),
             icon: <SupervisorAccountIcon />,
             route: "/" + ROUTE_POLICY_HOLDER_USERS,
-            filter: rights => rights.includes(RIGHT_PORTALPOLICYHOLDERUSER_SEARCH)
+            filter: rights =>
+                [
+                    RIGHT_POLICYHOLDERUSER_SEARCH,
+                    RIGHT_PORTALPOLICYHOLDERUSER_SEARCH
+                ].some(right => rights.includes(right))
         }
     ],
     "policyHolder.TabPanel.label": [

--- a/src/pages/PolicyHolderUsersPage.js
+++ b/src/pages/PolicyHolderUsersPage.js
@@ -4,7 +4,10 @@ import { injectIntl } from "react-intl";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { connect } from "react-redux";
 import PolicyHolderUserSearcher from "../components/PolicyHolderUserSearcher";
-import { RIGHT_PORTALPOLICYHOLDERUSER_SEARCH } from "../constants"
+import {
+    RIGHT_POLICYHOLDERUSER_SEARCH,
+    RIGHT_PORTALPOLICYHOLDERUSER_SEARCH
+} from "../constants"
 
 const styles = theme => ({
     page: theme.page
@@ -18,7 +21,10 @@ class PolicyHolderUsersPage extends Component {
     render() {
         const { classes, rights } = this.props;
         return (
-            rights.includes(RIGHT_PORTALPOLICYHOLDERUSER_SEARCH) && (
+            [
+                RIGHT_POLICYHOLDERUSER_SEARCH,
+                RIGHT_PORTALPOLICYHOLDERUSER_SEARCH
+            ].some(right => rights.includes(right)) && (
                 <div className={classes.page}>
                     <PolicyHolderUserSearcher
                         rights={rights}


### PR DESCRIPTION
As discussed offline with @delcroip users with `PolicyHolderUser` permissions (prefix: 1503) should also be able to access the Policy Holder User search page. Previously, only users with `PortalPolicyHolderUser` permissions (prefix: 1544) were able to access this page.