### PR TITLE
OFS-286: PHCPB searcher: replace CPB picker with PHCPB picker

### DIFF
--- a/src/components/PolicyHolderContributionPlanBundleSearcher.js
+++ b/src/components/PolicyHolderContributionPlanBundleSearcher.js
@@ -6,12 +6,12 @@ import {
     formatDateFromISO,
     Searcher,
     decodeId,
-    PublishedComponent,
     withTooltip,
     formatMessage,
     coreConfirm
 } from "@openimis/fe-core";
 import PolicyHolderContributionPlanBundleFilter from "./PolicyHolderContributionPlanBundleFilter";
+import PolicyHolderContributionPlanBundlePicker from "../pickers/PolicyHolderContributionPlanBundlePicker";
 import {
     fetchPolicyHolderContributionPlanBundles,
     fetchPickerPolicyHolderContributionPlanBundles,
@@ -105,10 +105,10 @@ class PolicyHolderContributionPlanBundleSearcher extends Component {
         const { intl, modulesManager, rights, policyHolder, onSave } = this.props;
         let result = [
             policyHolderContributionPlanBundle => !!policyHolderContributionPlanBundle.contributionPlanBundle
-                ? <PublishedComponent
-                    pubRef="contributionPlan.ContributionPlanBundlePicker"
+                ? <PolicyHolderContributionPlanBundlePicker
                     value={policyHolderContributionPlanBundle.contributionPlanBundle}
                     withLabel={false}
+                    policyHolderId={decodeId(policyHolder.id)}
                     readOnly />
                 : "",
             policyHolderContributionPlanBundle => !!policyHolderContributionPlanBundle.jsonExt ? policyHolderContributionPlanBundle.jsonExt : "",


### PR DESCRIPTION
In PHCPB searcher (displayed in a tab on Policy Holder card) CPB picker was used instead of PHCPB picker. Therefore, a user with PHCPB portal permissions could not see PHCPB values, because he was trying to fetch CPB values, which he has no permissions to.