### PR TITLE
OTC-1079: Return empty string instead of null

### DIFF
--- a/src/components/PolicyHolderContributionPlanBundleFilter.js
+++ b/src/components/PolicyHolderContributionPlanBundleFilter.js
@@ -19,7 +19,7 @@ const styles = theme => ({
 class PolicyHolderContributionPlanBundleFilter extends Component {
     _filterValue = k => {
         const { filters } = this.props;
-        return !!filters[k] ? filters[k].value : null
+        return !!filters[k] ? filters[k].value : "";
     }
 
     _onChangeFilter = (k, v) => {

--- a/src/components/PolicyHolderContributionPlanBundleFilter.js
+++ b/src/components/PolicyHolderContributionPlanBundleFilter.js
@@ -19,7 +19,7 @@ const styles = theme => ({
 class PolicyHolderContributionPlanBundleFilter extends Component {
     _filterValue = k => {
         const { filters } = this.props;
-        return !!filters[k] ? filters[k].value : "";
+        return !!filters[k] ? filters[k].value : null;
     }
 
     _onChangeFilter = (k, v) => {

--- a/src/components/PolicyHolderFilter.js
+++ b/src/components/PolicyHolderFilter.js
@@ -17,7 +17,7 @@ const styles = theme => ({
 class PolicyHolderFilter extends Component {
     _filterValue = k => {
         const { filters } = this.props;
-        return !!filters[k] ? filters[k].value : null
+        return !!filters[k] ? filters[k].value : "";
     }
 
     _onChangeFilter = (k, v) => {

--- a/src/components/PolicyHolderFilter.js
+++ b/src/components/PolicyHolderFilter.js
@@ -17,7 +17,12 @@ const styles = theme => ({
 class PolicyHolderFilter extends Component {
     _filterValue = k => {
         const { filters } = this.props;
-        return !!filters[k] ? filters[k].value : "";
+        return !!filters[k] ? filters[k].value : null;
+    }
+
+    _filterTextFieldValue = (key) => {
+        const { filters } = this.props;
+        return !!filters[key] ? filters[key].value : "";
     }
 
     _onChangeFilter = (k, v) => {
@@ -58,7 +63,7 @@ class PolicyHolderFilter extends Component {
                     <TextInput
                         module="policyHolder"
                         label="code"
-                        value={this._filterValue('code')}
+                        value={this._filterTextFieldValue('code')}
                         onChange={v => this._onChangeStringFilter('code', v, CONTAINS_LOOKUP)}
                     />
                 </Grid>
@@ -66,7 +71,7 @@ class PolicyHolderFilter extends Component {
                     <TextInput
                         module="policyHolder"
                         label="tradeName"
-                        value={this._filterValue('tradeName')}
+                        value={this._filterTextFieldValue('tradeName')}
                         onChange={v => this._onChangeStringFilter('tradeName', v, CONTAINS_LOOKUP)}
                     />
                 </Grid>

--- a/src/components/PolicyHolderInsureeFilter.js
+++ b/src/components/PolicyHolderInsureeFilter.js
@@ -22,6 +22,11 @@ class PolicyHolderInsureeFilter extends Component {
         return !!filters[k] ? filters[k].value : null
     }
 
+    _filterTextFieldValue = k => {
+        const { filters } = this.props;
+        return !!filters[k] ? filters[k].value : "";
+    }
+
     _onChangeFilter = (k, v) => {
         this.props.onChangeFilters([
             {
@@ -60,7 +65,7 @@ class PolicyHolderInsureeFilter extends Component {
                     <TextInput
                         module="policyHolder" 
                         label="insureeCHFID"
-                        value={this._filterValue('chfId')}
+                        value={this._filterTextFieldValue('insuree_ChfId')}
                         onChange={v => this._onChangeStringFilter('insuree_ChfId', v, STARTS_WITH_LOOKUP)}
                     />
                 </Grid>

--- a/src/components/PolicyHolderUserFilter.js
+++ b/src/components/PolicyHolderUserFilter.js
@@ -35,7 +35,7 @@ class PolicyHolderUserFilter extends Component {
 
     _filterValue = k => {
         const { filters } = this.props;
-        return !!filters[k] ? filters[k].value : null
+        return !!filters[k] ? filters[k].value : "";
     }
 
     _onChangeFilter = (k, v) => {

--- a/src/components/PolicyHolderUserFilter.js
+++ b/src/components/PolicyHolderUserFilter.js
@@ -35,7 +35,7 @@ class PolicyHolderUserFilter extends Component {
 
     _filterValue = k => {
         const { filters } = this.props;
-        return !!filters[k] ? filters[k].value : "";
+        return !!filters[k] ? filters[k].value : null;
     }
 
     _onChangeFilter = (k, v) => {


### PR DESCRIPTION
[OTC-1079](https://openimis.atlassian.net/browse/OTC-1079)

Changes:
- Return empty string instead of null. This change helps to clear all search fields properly.

[OTC-1079]: https://openimis.atlassian.net/browse/OTC-1079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ