### PR TITLE
OP-794: allow to add policy holder details after a new one is saved

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -111,11 +111,12 @@ export function fetchPickerPolicyHolders(params) {
   return graphql(payload, "POLICYHOLDER_POLICYHOLDERS");
 }
 
-export function fetchPolicyHolder(modulesManager, policyHolderId) {
+export function fetchPolicyHolder(modulesManager, policyHolderId, filters=[]) {
   let filter = !!policyHolderId ? `id: "${policyHolderId}"` : "";
+  filters.push(filter)
   const payload = formatPageQuery(
     "policyHolder",
-    [filter],
+    filters,
     POLICYHOLDER_FULL_PROJECTION(modulesManager)
   );
   return graphql(payload, "POLICYHOLDER_POLICYHOLDER");
@@ -134,6 +135,12 @@ export function fetchPolicyHolderInsurees(modulesManager, params) {
     POLICYHOLDERINSUREE_FULL_PROJECTION(modulesManager)
   );
   return graphql(payload, "POLICYHOLDER_POLICYHOLDERINSUREES");
+}
+
+export function clearPolicyHolderInsurees() {
+  return (dispatch) => {
+    dispatch({ type: "POLICYHOLDER_POLICYHOLDERINSUREES_CLEAR" });
+  };
 }
 
 export function fetchPickerPolicyHolderInsurees(modulesManager, params) {

--- a/src/components/PolicyHolderForm.js
+++ b/src/components/PolicyHolderForm.js
@@ -14,8 +14,9 @@ import {
   formatMessageWithValues,
   journalize,
   Helmet,
+  decodeId,
 } from "@openimis/fe-core";
-import { fetchPolicyHolder, clearPolicyHolder } from "../actions";
+import { fetchPolicyHolder, clearPolicyHolder, clearPolicyHolderInsurees } from "../actions";
 import {
   RIGHT_PORTALPOLICYHOLDER_SEARCH,
   RIGHT_POLICYHOLDER_CREATE,
@@ -86,14 +87,22 @@ class PolicyHolderForm extends Component {
         policyHolder: props.policyHolder,
         policyHolderId: props.policyHolderId,
       }));
+      const policyHolderRouteRef = this.props.modulesManager.getRef('policyHolder.route.policyHolder');
+      const decodedId = decodeId(this.props.policyHolder.id);
+      this.props.history.replace(`/${policyHolderRouteRef}/${decodedId}`);
     }
     if (prevProps.submittingMutation && !this.props.submittingMutation) {
       this.props.journalize(this.props.mutation);
+      if (!this.props?.policyHolderId) {
+        this.props.fetchPolicyHolder(this.props.modulesManager, null, [`clientMutationId: "${this.props.mutation.clientMutationId}"`]);
+      }
     }
   }
 
   componentWillUnmount() {
     this.props.clearPolicyHolder();
+    //if different default tab under policyholder then it needs to be cleared according to default tab
+    this.props.clearPolicyHolderInsurees();
   }
 
   isMandatoryFieldsEmpty = () => {
@@ -199,7 +208,11 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = (dispatch) => {
   return bindActionCreators(
-    { fetchPolicyHolder, clearPolicyHolder, journalize },
+    { fetchPolicyHolder,
+      clearPolicyHolder,
+      clearPolicyHolderInsurees,
+      journalize,
+    },
     dispatch
   );
 };

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -149,6 +149,16 @@ function reducer(
         fetchingPolicyHolderInsurees: false,
         errorPolicyHolderInsurees: formatServerError(action.payload),
       };
+    case "POLICYHOLDER_POLICYHOLDERINSUREES_CLEAR":
+      return {
+        ...state,
+        fetchingPolicyHolderInsurees: false,
+        fetchedPolicyHolderInsurees: false,
+        policyHolderInsurees: [],
+        policyHolderInsureesPageInfo: {},
+        policyHolderInsureesTotalCount: 0,
+        errorPolicyHolderInsurees: null,
+      };
     case "POLICYHOLDER_PICKERPOLICYHOLDERINSUREES_REQ":
       return {
         ...state,


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OP-794

This PR allows to add policy holder details in the tab panels right after new policy holder is saved.

It needs: https://github.com/openimis/openimis-be-policyholder_py/pull/64