### PR TITLE
OP-1725: remove null/empty option from dropdown

### DIFF
--- a/src/components/PolicyHolderGeneralInfoPanel.js
+++ b/src/components/PolicyHolderGeneralInfoPanel.js
@@ -312,8 +312,7 @@ class PolicyHolderGeneralInfoPanel extends FormPanel {
               pubRef="policyHolder.LegalFormPicker"
               module="policyHolder"
               label="legalForm"
-              withNull
-              nullLabel={formatMessage(intl, "policyHolder", "emptyLabel")}
+              withNull={false}
               value={!!edited ? edited.legalForm : null}
               onChange={(v) => this.updateAttribute("legalForm", v)}
               readOnly={isPolicyHolderPortalUser}
@@ -324,8 +323,7 @@ class PolicyHolderGeneralInfoPanel extends FormPanel {
               pubRef="policyHolder.ActivityCodePicker"
               module="policyHolder"
               label="activityCode"
-              withNull
-              nullLabel={formatMessage(intl, "policyHolder", "emptyLabel")}
+              withNull={false}
               value={!!edited ? edited.activityCode : null}
               onChange={(v) => this.updateAttribute("activityCode", v)}
               readOnly={isPolicyHolderPortalUser}

--- a/src/dialogs/CreatePolicyHolderContributionPlanBundleDialog.js
+++ b/src/dialogs/CreatePolicyHolderContributionPlanBundleDialog.js
@@ -93,7 +93,7 @@ class CreatePolicyHolderContributionPlanBundleDialog extends Component {
                             <Grid item className={classes.item}>
                                 <PublishedComponent
                                     pubRef="contributionPlan.ContributionPlanBundlePicker"
-                                    withNull={true}
+                                    withNull={false}
                                     required
                                     value={!!policyHolderContributionPlanBundle.contributionPlanBundle && policyHolderContributionPlanBundle.contributionPlanBundle}
                                     onChange={v => this.updateAttribute('contributionPlanBundle', v)}

--- a/src/dialogs/CreatePolicyHolderInsureeDialog.js
+++ b/src/dialogs/CreatePolicyHolderInsureeDialog.js
@@ -116,7 +116,7 @@ class CreatePolicyHolderInsureeDialog extends Component {
                             </Grid>
                             <Grid item className={classes.item}>
                                 <PolicyHolderContributionPlanBundlePicker
-                                    withNull={true}
+                                    withNull={false}
                                     required
                                     policyHolderId={!!policyHolderInsuree.policyHolder && decodeId(policyHolderInsuree.policyHolder.id)}
                                     value={!!policyHolderInsuree.contributionPlanBundle && policyHolderInsuree.contributionPlanBundle}

--- a/src/dialogs/CreatePolicyHolderUserDialog.js
+++ b/src/dialogs/CreatePolicyHolderUserDialog.js
@@ -115,8 +115,6 @@ class CreatePolicyHolderUserDialog extends Component {
                             <Grid item className={classes.item}>
                                 <PolicyHolderPicker
                                     module="policyHolder"
-                                    withNull
-                                    nullLabel={formatMessage(intl, "policyHolder", "emptyLabel")}
                                     value={!!policyHolderUser.policyHolder && policyHolderUser.policyHolder}
                                     onChange={(v) => this.updateAttribute("policyHolder", v)}
                                     readOnly={!!predefinedPolicyHolderId}


### PR DESCRIPTION
[OP-1725](https://openimis.atlassian.net/browse/OP-1725)

Changes:

- Remove the 'none/null' option from the dropdowns menu in the form.

[OP-1725]: https://openimis.atlassian.net/browse/OP-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ