### PR TITLE
OM-148: save eu in store

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -816,3 +816,9 @@ export const policyHolderCodeClear = () => {
     dispatch({ type: "POLICYHOLDER_CODE_FIELDS_VALIDATION_CLEAR" });
   };
 };
+
+export const saveEconomicUnit = (economicUnit) => {
+  return (dispatch) => {
+    dispatch({ type: "SAVE_ECONOMIC_UNIT", payload: economicUnit });
+  };
+}

--- a/src/dialogs/EconomicUnitDialog.js
+++ b/src/dialogs/EconomicUnitDialog.js
@@ -12,6 +12,7 @@ import {
 import { makeStyles } from '@material-ui/styles';
 
 import { useTranslations, useModulesManager, redirectToSamlLogout } from '@openimis/fe-core';
+import { saveEconomicUnit } from '../actions';
 import { ECONOMIC_UNIT_STORAGE_KEY, MODULE_NAME } from '../constants';
 import EconomicUnitPicker from '../pickers/EconomicUnitPicker';
 
@@ -20,7 +21,7 @@ const useStyles = makeStyles((theme) => ({
   secondaryButton: theme.dialog.secondaryButton,
 }));
 
-const EconomicUnitDialog = ({ open, setEconomicUnitDialogOpen, onLogout }) => {
+const EconomicUnitDialog = ({ open, setEconomicUnitDialogOpen }) => {
   const modulesManager = useModulesManager();
   const dispatch = useDispatch();
   const classes = useStyles();
@@ -40,6 +41,7 @@ const EconomicUnitDialog = ({ open, setEconomicUnitDialogOpen, onLogout }) => {
   const onConfirm = () => {
     if (value) {
       localStorage.setItem(ECONOMIC_UNIT_STORAGE_KEY, JSON.stringify(value));
+      dispatch(saveEconomicUnit(value));
       setEconomicUnitDialogOpen(false);
     }
   };

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -359,14 +359,10 @@ function reducer(
         },
       };
     case 'SAVE_ECONOMIC_UNIT':
-      try {
-        return {
-          ...state,
-          economicUnit: action.payload,
-        };
-      } catch (error) {
-        console.error('[SAVE_ECONOMIC_UNIT]: ', error);
-      }
+      return {
+        ...state,
+        economicUnit: action.payload,
+      };
     case "POLICYHOLDER_MUTATION_REQ":
       return dispatchMutationReq(state, action);
     case "POLICYHOLDER_MUTATION_ERR":

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -7,6 +7,7 @@ import {
   dispatchMutationResp,
   dispatchMutationErr,
 } from "@openimis/fe-core";
+import { ECONOMIC_UNIT_STORAGE_KEY } from "./constants";
 
 function reducer(
   state = {
@@ -52,6 +53,7 @@ function reducer(
     policyHolderUsers: [],
     policyHolderUsersPageInfo: {},
     policyHolderUsersTotalCount: 0,
+    economicUnit: JSON.parse(localStorage.getItem(ECONOMIC_UNIT_STORAGE_KEY) ?? '{}'),
   },
   action
 ) {
@@ -356,6 +358,15 @@ function reducer(
           },
         },
       };
+    case 'SAVE_ECONOMIC_UNIT':
+      try {
+        return {
+          ...state,
+          economicUnit: action.payload,
+        };
+      } catch (error) {
+        console.error('[SAVE_ECONOMIC_UNIT]: ', error);
+      }
     case "POLICYHOLDER_MUTATION_REQ":
       return dispatchMutationReq(state, action);
     case "POLICYHOLDER_MUTATION_ERR":


### PR DESCRIPTION
[OM-148](https://openimis.atlassian.net/browse/OM-148)

https://github.com/openimis/openimis-fe-worker_voucher_js/pull/31

Changes:
- Save EU in Redux store to be able to track it's change.

[OM-148]: https://openimis.atlassian.net/browse/OM-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ