### PR TITLE
OP-1876: Disable edit of PolicyHolder code in edit mode

### DIFF
--- a/src/components/PolicyHolderGeneralInfoPanel.js
+++ b/src/components/PolicyHolderGeneralInfoPanel.js
@@ -230,7 +230,7 @@ class PolicyHolderGeneralInfoPanel extends FormPanel {
               label="code"
               value={!!edited && !!edited.code ? edited.code : ""}
               onChange={(v) => this.updateAttribute("code", v)}
-              readOnly={isPolicyHolderPortalUser}
+              readOnly={(!!edited && !!edited.id) || isPolicyHolderPortalUser}
             />
           </Grid>
           <Grid item xs={2} className={classes.item}>


### PR DESCRIPTION
Ticket: [OP-1876](https://openimis.atlassian.net/browse/OP-1876)

PolicyHolder Code cannot be updated. This PR grays out the field in the PH view. 

[OP-1876]: https://openimis.atlassian.net/browse/OP-1876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ