### PR TITLE
OP-1906: Added refresh for tabs in PH view

### DIFF
--- a/src/components/PolicyHolderContributionPlanBundlesTab.js
+++ b/src/components/PolicyHolderContributionPlanBundlesTab.js
@@ -9,6 +9,7 @@ import {
 } from "../constants";
 import PolicyHolderContributionPlanBundleSearcher from "./PolicyHolderContributionPlanBundleSearcher";
 import CreatePolicyHolderContributionPlanBundleDialog from "../dialogs/CreatePolicyHolderContributionPlanBundleDialog";
+import { connect } from "react-redux";
 
 class PolicyHolderContributionPlanBundlesTabLabel extends Component {
     render() {
@@ -29,12 +30,9 @@ class PolicyHolderContributionPlanBundlesTabLabel extends Component {
     }
 }
 
-class PolicyHolderContributionPlanBundlesTabPanel extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            reset: 0
-        }
+class PolicyHolderContributionPlanBundlesTab extends Component {
+    state = {
+        reset: 0,
     }
 
     onSave = () => {
@@ -42,6 +40,18 @@ class PolicyHolderContributionPlanBundlesTabPanel extends Component {
             reset: state.reset + 1
         }));
     }
+
+    componentDidUpdate(prevProps) {
+        if (!prevProps.created && this.props.created) {
+          this.onSave();
+        }
+        if (!prevProps.updated && this.props.updated) {
+          this.onSave();
+        }
+        if (!prevProps.replaced && this.props.replaced) {
+          this.onSave();
+        }
+      }
 
     render() {
         const { rights, value, isTabsEnabled, policyHolder } = this.props;
@@ -66,7 +76,8 @@ class PolicyHolderContributionPlanBundlesTabPanel extends Component {
                                     <Grid item>
                                         <CreatePolicyHolderContributionPlanBundleDialog
                                             policyHolder={policyHolder}
-                                            onSave={this.onSave}
+                                            onSave={() => {}}
+                                            tabView
                                         />
                                     </Grid>
                                 </Grid>
@@ -84,6 +95,15 @@ class PolicyHolderContributionPlanBundlesTabPanel extends Component {
         )
     }
 }
+
+const mapStateToProps = (state) => ({
+    created: !!state.policyHolder ? state.policyHolder.policyholderCreatePolicyholdercontributionplanbundleResp : false,
+    updated: !!state.policyHolder ? state.policyHolder.policyholderReplacePolicyholdercontributionplanbundleResp : false,
+    replaced: !!state.policyHolder ? state.policyHolder.policyholderUpdatePolicyholdercontributionplanbundleResp : false,
+});
+  
+
+const PolicyHolderContributionPlanBundlesTabPanel = connect(mapStateToProps)(PolicyHolderContributionPlanBundlesTab) 
 
 export {
     PolicyHolderContributionPlanBundlesTabLabel,

--- a/src/components/PolicyHolderInsureesTab.js
+++ b/src/components/PolicyHolderInsureesTab.js
@@ -10,6 +10,7 @@ import {
 import PolicyHolderInsureeSearcher from "./PolicyHolderInsureeSearcher";
 import { POLICYHOLDERINSUREE_TAB_VALUE } from "../constants"
 import CreatePolicyHolderInsureeDialog from "../dialogs/CreatePolicyHolderInsureeDialog";
+import { connect } from "react-redux";
 
 class PolicyHolderInsureesTabLabel extends Component {
     render() {
@@ -30,12 +31,9 @@ class PolicyHolderInsureesTabLabel extends Component {
     }
 }
 
-class PolicyHolderInsureesTabPanel extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            reset: 0
-        }
+class PolicyHolderInsureesTab extends Component {
+    state = {
+        reset: 0,
     }
 
     onSave = () => {
@@ -43,6 +41,18 @@ class PolicyHolderInsureesTabPanel extends Component {
             reset: state.reset + 1
         }));
     }
+
+    componentDidUpdate(prevProps) {
+        if (!prevProps.created && this.props.created) {
+          this.onSave();
+        }
+        if (!prevProps.updated && this.props.updated) {
+          this.onSave();
+        }
+        if (!prevProps.replaced && this.props.replaced) {
+          this.onSave();
+        }
+      }
 
     render() {
         const { rights, value, isTabsEnabled, policyHolder } = this.props;
@@ -99,6 +109,15 @@ class PolicyHolderInsureesTabPanel extends Component {
         );
     }
 }
+
+const mapStateToProps = (state) => ({
+    created: !!state.policyHolder ? state.policyHolder.policyholderCreatePolicyholderinsureeResp : false,
+    updated: !!state.policyHolder ? state.policyHolder.policyholderUpdatePolicyholderinsureeResp : false,
+    replaced: !!state.policyHolder ? state.policyHolder.policyholderReplacePolicyholderinsureeResp : false,
+});
+  
+const PolicyHolderInsureesTabPanel = connect(mapStateToProps)(PolicyHolderInsureesTab) 
+
 
 export {
     PolicyHolderInsureesTabLabel,

--- a/src/components/PolicyHolderUserSearcher.js
+++ b/src/components/PolicyHolderUserSearcher.js
@@ -147,17 +147,9 @@ class PolicyHolderUserSearcher extends Component {
         `
           : "",
     ];
-    if (predefinedPolicyHolderId === null) {
       result.push((policyHolderUser) => (
-        <PolicyHolderPicker
-          value={
-            !!policyHolderUser.policyHolder && policyHolderUser.policyHolder
-          }
-          withLabel={false}
-          readOnly
-        />
+        !!policyHolderUser.policyHolder ? `${policyHolderUser.policyHolder.code} - ${policyHolderUser.policyHolder.tradeName}` : ''
       ));
-    }
     result.push(
       (policyHolderUser) =>
         !!policyHolderUser.dateValidFrom

--- a/src/components/PolicyHolderUsersTab.js
+++ b/src/components/PolicyHolderUsersTab.js
@@ -10,6 +10,7 @@ import {
 import { POLICYHOLDERUSER_TAB_VALUE } from "../constants"
 import PolicyHolderUserSearcher from "./PolicyHolderUserSearcher";
 import CreatePolicyHolderUserDialog from "../dialogs/CreatePolicyHolderUserDialog";
+import { connect } from "react-redux";
 
 class PolicyHolderUsersTabLabel extends Component {
     render() {
@@ -32,15 +33,28 @@ class PolicyHolderUsersTabLabel extends Component {
     }
 }
 
-class PolicyHolderUsersTabPanel extends Component {
+class PolicyHolderUsersTab extends Component {
     state = {
-        reset: 0
+        reset: 0,
     }
 
-    onSave = () =>
+    onSave = () => {
         this.setState(state => ({
             reset: state.reset + 1
         }));
+    }
+
+    componentDidUpdate(prevProps) {
+        if (!prevProps.created && this.props.created) {
+          this.onSave();
+        }
+        if (!prevProps.updated && this.props.updated) {
+          this.onSave();
+        }
+        if (!prevProps.replaced && this.props.replaced) {
+          this.onSave();
+        }
+      }
 
     render() {
         const { rights, value, isTabsEnabled, policyHolder } = this.props;
@@ -90,6 +104,15 @@ class PolicyHolderUsersTabPanel extends Component {
         );
     }
 }
+
+const mapStateToProps = (state) => ({
+    created: !!state.policyHolder ? state.policyHolder.policyholderCreatePolicyholderuserResp : false,
+    updated: !!state.policyHolder ? state.policyHolder.policyholderUpdatePolicyholderuserResp : false,
+    replaced: !!state.policyHolder ? state.policyHolder.policyholderReplacePolicyholderuserResp : false,
+});
+  
+const PolicyHolderUsersTabPanel = connect(mapStateToProps)(PolicyHolderUsersTab) 
+
 
 export {
     PolicyHolderUsersTabLabel,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -54,6 +54,69 @@ function reducer(
     policyHolderUsersPageInfo: {},
     policyHolderUsersTotalCount: 0,
     economicUnit: JSON.parse(localStorage.getItem(ECONOMIC_UNIT_STORAGE_KEY) ?? '{}'),
+    policyholderMutationReq: false,
+    policyholderMutationErr: false,
+    policyholderMutationResp: false,
+    
+    policyholderCreatePolicyholderReq: false,
+    policyholderCreatePolicyholderResp: false,
+    policyholderCreatePolicyholderErr: false,
+    
+    policyholderUpdatePolicyholderReq: false,
+    policyholderUpdatePolicyholderResp: false,
+    policyholderUpdatePolicyholderErr: false,
+
+    policyholderDeletePolicyholderReq: false,
+    policyholderDeletePolicyholderResp: false,
+    policyholderDeletePolicyholderErr: false,
+
+    policyholderCreatePolicyholderinsureeReq: false,
+    policyholderCreatePolicyholderinsureeResp: false,
+    policyholderCreatePolicyholderinsureeErr: false,
+
+    policyholderUpdatePolicyholderinsureeReq: false,
+    policyholderUpdatePolicyholderinsureeResp: false,
+    policyholderUpdatePolicyholderinsureeErr: false,
+    
+    policyholderDeletePolicyholderinsureeReq: false,
+    policyholderDeletePolicyholderinsureeResp: false,
+    policyholderDeletePolicyholderinsureeErr: false,
+
+    policyholderReplacePolicyholderinsureeReq: false,
+    policyholderReplacePolicyholderinsureeResp: false,
+    policyholderReplacePolicyholderinsureeErr: false,
+    
+    policyholderCreatePolicyholdercontributionplanbundleReq: false,
+    policyholderCreatePolicyholdercontributionplanbundleResp: false,
+    policyholderCreatePolicyholdercontributionplanbundleErr: false,
+    
+    policyholderUpdatePolicyholdercontributionplanbundleReq: false,
+    policyholderUpdatePolicyholdercontributionplanbundleResp: false,
+    policyholderUpdatePolicyholdercontributionplanbundleErr: false,
+    
+    policyholderDeletePolicyholdercontributionplanbundleReq: false,
+    policyholderDeletePolicyholdercontributionplanbundleResp: false,
+    policyholderDeletePolicyholdercontributionplanbundleErr: false,
+
+    policyholderReplacePolicyholdercontributionplanbundleReq: false,
+    policyholderReplacePolicyholdercontributionplanbundleResp: false,
+    policyholderReplacePolicyholdercontributionplanbundleRErr: false,
+    
+    policyholderCreatePolicyholderuserReq: false,
+    policyholderCreatePolicyholderuserResp: false,
+    policyholderCreatePolicyholderuserErr: false,
+    
+    policyholderUpdatePolicyholderuserReq: false,
+    policyholderUpdatePolicyholderuserResp: false,
+    policyholderUpdatePolicyholderuserErr: false,
+
+    policyholderDeletePolicyholderuserReq: false,
+    policyholderDeletePolicyholderuserResp: false,
+    policyholderDeletePolicyholderuserErr: false,
+
+    policyholderReplacePolicyholderuserReq: false,
+    policyholderReplacePolicyholderuserResp: false,
+    policyholderReplacePolicyholderuserErr: false,
   },
   action
 ) {
@@ -364,55 +427,377 @@ function reducer(
         economicUnit: action.payload,
       };
     case "POLICYHOLDER_MUTATION_REQ":
-      return dispatchMutationReq(state, action);
+      return dispatchMutationReq({
+        ...state,
+        policyholderMutationReq: true,
+        policyholderMutationErr: false,
+        policyholderMutationResp: false,
+        }, action);
     case "POLICYHOLDER_MUTATION_ERR":
-      return dispatchMutationErr(state, action);
+      return dispatchMutationErr({
+        ...state,
+        policyholderMutationReq: false,
+        policyholderMutationErr: true,
+        policyholderMutationResp: false,
+        }, action);
+    case "POLICYHOLDER_MUTATION_RESP":
+      return dispatchMutationErr({
+        ...state,
+        policyholderMutationReq: false,
+        policyholderMutationErr: false,
+        policyholderMutationResp: true,
+        }, action);
+    case "POLICYHOLDER_CREATE_POLICYHOLDER_REQ":
+      return dispatchMutationResp({
+        ...state,
+        policyholderCreatePolicyholderReq: true,
+        policyholderCreatePolicyholderResp: false,
+        policyholderCreatePolicyholderErr: false,
+        }, "createPolicyHolder", action);
     case "POLICYHOLDER_CREATE_POLICYHOLDER_RESP":
-      return dispatchMutationResp(state, "createPolicyHolder", action);
+      return dispatchMutationResp({
+        ...state,
+        policyholderCreatePolicyholderReq: false,
+        policyholderCreatePolicyholderResp: true,
+        policyholderCreatePolicyholderErr: false,
+        }, "createPolicyHolder", action);
+    case "POLICYHOLDER_CREATE_POLICYHOLDER_ERR":
+      return dispatchMutationResp({
+        ...state,
+        policyholderCreatePolicyholderReq: false,
+        policyholderCreatePolicyholderResp: false,
+        policyholderCreatePolicyholderErr: true
+        }, "createPolicyHolder", action);
+    case "POLICYHOLDER_UPDATE_POLICYHOLDER_REQ":
+      return dispatchMutationResp({
+        ...state,
+        policyholderUpdatePolicyholderReq: true,
+        policyholderUpdatePolicyholderResp: false,
+        policyholderUpdatePolicyholderErr: false,
+      }, "updatePolicyHolder", action);
     case "POLICYHOLDER_UPDATE_POLICYHOLDER_RESP":
-      return dispatchMutationResp(state, "updatePolicyHolder", action);
+      return dispatchMutationResp({
+        ...state,
+        policyholderUpdatePolicyholderReq: false,
+        policyholderUpdatePolicyholderResp: true,
+        policyholderUpdatePolicyholderErr: false,
+      }, "updatePolicyHolder", action);
+    case "POLICYHOLDER_UPDATE_POLICYHOLDER_RESP":
+      return dispatchMutationResp({
+        ...state,
+        policyholderUpdatePolicyholderReq: false,
+        policyholderUpdatePolicyholderResp: false,
+        policyholderUpdatePolicyholderErr: true,
+      }, "updatePolicyHolder", action);
+    case "POLICYHOLDER_DELETE_POLICYHOLDER_REQ":
+      return dispatchMutationResp({
+        ...state,
+        policyholderDeletePolicyholderReq: true,
+        policyholderDeletePolicyholderResp: false,
+        policyholderDeletePolicyholderErr: false,
+      }, "deletePolicyHolder", action);
     case "POLICYHOLDER_DELETE_POLICYHOLDER_RESP":
-      return dispatchMutationResp(state, "deletePolicyHolder", action);
+      return dispatchMutationResp({
+        ...state,
+        policyholderDeletePolicyholderReq: false,
+        policyholderDeletePolicyholderResp: true,
+        policyholderDeletePolicyholderErr: false,
+      }, "deletePolicyHolder", action);
+    case "POLICYHOLDER_DELETE_POLICYHOLDER_ERR":
+      return dispatchMutationResp({
+        ...state,
+        policyholderDeletePolicyholderReq: false,
+        policyholderDeletePolicyholderResp: false,
+        policyholderDeletePolicyholderErr: true,
+      }, "deletePolicyHolder", action);
+    case "POLICYHOLDER_CREATE_POLICYHOLDERINSUREE_REQ":
+      return dispatchMutationResp({
+        ...state,
+        policyholderCreatePolicyholderinsureeReq: true,
+        policyholderCreatePolicyholderinsureeResp: false,
+        policyholderCreatePolicyholderinsureeErr: false,
+      }, "createPolicyHolderInsuree", action);
     case "POLICYHOLDER_CREATE_POLICYHOLDERINSUREE_RESP":
-      return dispatchMutationResp(state, "createPolicyHolderInsuree", action);
+      return dispatchMutationResp({
+        ...state,
+        policyholderCreatePolicyholderinsureeReq: false,
+        policyholderCreatePolicyholderinsureeResp: true,
+        policyholderCreatePolicyholderinsureeErr: false,
+      }, "createPolicyHolderInsuree", action);
+    case "POLICYHOLDER_CREATE_POLICYHOLDERINSUREE_ERR":
+      return dispatchMutationResp({
+        ...state,
+        policyholderCreatePolicyholderinsureeReq: false,
+        policyholderCreatePolicyholderinsureeResp: false,
+        policyholderCreatePolicyholderinsureeErr: true,
+      }, "createPolicyHolderInsuree", action);
+    case "POLICYHOLDER_UPDATE_POLICYHOLDERINSUREE_REQ":
+      return dispatchMutationResp({
+        ...state,
+        policyholderUpdatePolicyholderinsureeReq: true,
+        policyholderUpdatePolicyholderinsureeResp: false,
+        policyholderUpdatePolicyholderinsureeErr: false,
+      }, "updatePolicyHolderInsuree", action);
     case "POLICYHOLDER_UPDATE_POLICYHOLDERINSUREE_RESP":
-      return dispatchMutationResp(state, "updatePolicyHolderInsuree", action);
+      return dispatchMutationResp({
+        ...state,
+        policyholderUpdatePolicyholderinsureeReq: false,
+        policyholderUpdatePolicyholderinsureeResp: true,
+        policyholderUpdatePolicyholderinsureeErr: false,
+      }, "updatePolicyHolderInsuree", action);
+    case "POLICYHOLDER_UPDATE_POLICYHOLDERINSUREE_RESP":
+      return dispatchMutationResp({
+        ...state,
+        policyholderUpdatePolicyholderinsureeReq: false,
+        policyholderUpdatePolicyholderinsureeResp: false,
+        policyholderUpdatePolicyholderinsureeErr: true,
+      }, "updatePolicyHolderInsuree", action);
+    case "POLICYHOLDER_DELETE_POLICYHOLDERINSUREE_REQ":
+      return dispatchMutationResp({
+        ...state,
+        policyholderDeletePolicyholderinsureeReq: true,
+        policyholderDeletePolicyholderinsureeResp: false,
+        policyholderDeletePolicyholderinsureeErr: false,    
+      }, "deletePolicyHolderInsuree", action);
     case "POLICYHOLDER_DELETE_POLICYHOLDERINSUREE_RESP":
-      return dispatchMutationResp(state, "deletePolicyHolderInsuree", action);
+      return dispatchMutationResp({
+        ...state,
+        policyholderDeletePolicyholderinsureeReq: false,
+        policyholderDeletePolicyholderinsureeResp: true,
+        policyholderDeletePolicyholderinsureeErr: false,    
+      }, "deletePolicyHolderInsuree", action);
+    case "POLICYHOLDER_DELETE_POLICYHOLDERINSUREE_ERR":
+      return dispatchMutationResp({
+        ...state,
+        policyholderDeletePolicyholderinsureeReq: false,
+        policyholderDeletePolicyholderinsureeResp: false,
+        policyholderDeletePolicyholderinsureeErr: true,    
+      }, "deletePolicyHolderInsuree", action);
+    case "POLICYHOLDER_REPLACE_POLICYHOLDERINSUREE_REQ":
+      return dispatchMutationResp({
+        ...state,
+        policyholderReplacePolicyholderinsureeReq: true,
+        policyholderReplacePolicyholderinsureeResp: false,
+        policyholderReplacePolicyholderinsureeErr: false,
+      }, "replacePolicyHolderInsuree", action);
     case "POLICYHOLDER_REPLACE_POLICYHOLDERINSUREE_RESP":
-      return dispatchMutationResp(state, "replacePolicyHolderInsuree", action);
-    case "POLICYHOLDER_CREATE_POLICYHOLDERCONTRIBUTIONPLANBUNDLE_RESP":
-      return dispatchMutationResp(
-        state,
+      return dispatchMutationResp({
+        ...state,
+        policyholderReplacePolicyholderinsureeReq: false,
+        policyholderReplacePolicyholderinsureeResp: true,
+        policyholderReplacePolicyholderinsureeErr: false,
+      }, "replacePolicyHolderInsuree", action);
+    case "POLICYHOLDER_REPLACE_POLICYHOLDERINSUREE_ERR":
+      return dispatchMutationResp({
+        ...state,
+        policyholderReplacePolicyholderinsureeReq: false,
+        policyholderReplacePolicyholderinsureeResp: false,
+        policyholderReplacePolicyholderinsureeErr: true,
+      }, "replacePolicyHolderInsuree", action);
+    case "POLICYHOLDER_CREATE_POLICYHOLDERCONTRIBUTIONPLANBUNDLE_REQ":
+      return dispatchMutationResp({
+        ...state,
+        policyholderCreatePolicyholdercontributionplanbundleReq: true,
+        policyholderCreatePolicyholdercontributionplanbundleResp: false,
+        policyholderCreatePolicyholdercontributionplanbundleErr: false,    
+        },
         "createPolicyHolderContributionPlanBundle",
         action
       );
-    case "POLICYHOLDER_UPDATE_POLICYHOLDERCONTRIBUTIONPLANBUNDLE_RESP":
-      return dispatchMutationResp(
-        state,
+    case "POLICYHOLDER_CREATE_POLICYHOLDERCONTRIBUTIONPLANBUNDLE_RESP":
+      return dispatchMutationResp({
+        ...state,
+        policyholderCreatePolicyholdercontributionplanbundleReq: false,
+        policyholderCreatePolicyholdercontributionplanbundleResp: true,
+        policyholderCreatePolicyholdercontributionplanbundleErr: false,    
+        },
+        "createPolicyHolderContributionPlanBundle",
+        action
+      );
+    case "POLICYHOLDER_CREATE_POLICYHOLDERCONTRIBUTIONPLANBUNDLE_ERR":
+      return dispatchMutationResp({
+        ...state,
+        policyholderCreatePolicyholdercontributionplanbundleReq: false,
+        policyholderCreatePolicyholdercontributionplanbundleResp: false,
+        policyholderCreatePolicyholdercontributionplanbundleErr: true,    
+        },
+        "createPolicyHolderContributionPlanBundle",
+        action
+      );
+    case "POLICYHOLDER_UPDATE_POLICYHOLDERCONTRIBUTIONPLANBUNDLE_REQ":
+      return dispatchMutationResp({
+        ...state,
+        policyholderUpdatePolicyholdercontributionplanbundleReq: true,
+        policyholderUpdatePolicyholdercontributionplanbundleResp: false,
+        policyholderUpdatePolicyholdercontributionplanbundleErr: false,
+        },
         "updatePolicyHolderContributionPlanBundle",
         action
       );
-    case "POLICYHOLDER_DELETE_POLICYHOLDERCONTRIBUTIONPLANBUNDLE_RESP":
-      return dispatchMutationResp(
-        state,
+    case "POLICYHOLDER_UPDATE_POLICYHOLDERCONTRIBUTIONPLANBUNDLE_RESP":
+      return dispatchMutationResp({
+        ...state,
+        policyholderUpdatePolicyholdercontributionplanbundleReq: false,
+        policyholderUpdatePolicyholdercontributionplanbundleResp: true,
+        policyholderUpdatePolicyholdercontributionplanbundleErr: false,
+        },
+        "updatePolicyHolderContributionPlanBundle",
+        action
+      );
+    case "POLICYHOLDER_UPDATE_POLICYHOLDERCONTRIBUTIONPLANBUNDLE_ERR":
+      return dispatchMutationResp({
+        ...state,
+        policyholderUpdatePolicyholdercontributionplanbundleReq: false,
+        policyholderUpdatePolicyholdercontributionplanbundleResp: false,
+        policyholderUpdatePolicyholdercontributionplanbundleErr: true,
+        },
+        "updatePolicyHolderContributionPlanBundle",
+        action
+      );
+    case "POLICYHOLDER_DELETE_POLICYHOLDERCONTRIBUTIONPLANBUNDLE_REQ":
+      return dispatchMutationResp({
+        ...state,  
+        policyholderDeletePolicyholdercontributionplanbundleReq: true,
+        policyholderDeletePolicyholdercontributionplanbundleResp: false,
+        policyholderDeletePolicyholdercontributionplanbundleErr: false,
+        },
         "deletePolicyHolderContributionPlanBundle",
         action
       );
-    case "POLICYHOLDER_REPLACE_POLICYHOLDERCONTRIBUTIONPLANBUNDLE_RESP":
-      return dispatchMutationResp(
-        state,
+    case "POLICYHOLDER_DELETE_POLICYHOLDERCONTRIBUTIONPLANBUNDLE_RESP":
+      return dispatchMutationResp({
+        ...state,  
+        policyholderDeletePolicyholdercontributionplanbundleReq: false,
+        policyholderDeletePolicyholdercontributionplanbundleResp: true,
+        policyholderDeletePolicyholdercontributionplanbundleErr: false,
+        },
+        "deletePolicyHolderContributionPlanBundle",
+        action
+      );
+    case "POLICYHOLDER_DELETE_POLICYHOLDERCONTRIBUTIONPLANBUNDLE_ERR":
+      return dispatchMutationResp({
+        ...state,  
+        policyholderDeletePolicyholdercontributionplanbundleReq: false,
+        policyholderDeletePolicyholdercontributionplanbundleResp: false,
+        policyholderDeletePolicyholdercontributionplanbundleErr: true,
+        },
+        "deletePolicyHolderContributionPlanBundle",
+        action
+      );
+    case "POLICYHOLDER_REPLACE_POLICYHOLDERCONTRIBUTIONPLANBUNDLE_REQ":
+      return dispatchMutationResp({
+        ...state,    
+        policyholderReplacePolicyholdercontributionplanbundleReq: true,
+        policyholderReplacePolicyholdercontributionplanbundleResp: false,
+        policyholderReplacePolicyholdercontributionplanbundleRErr: false,
+      },
         "replacePolicyHolderContributionPlanBundle",
         action
       );
+    case "POLICYHOLDER_REPLACE_POLICYHOLDERCONTRIBUTIONPLANBUNDLE_RESP":
+      return dispatchMutationResp({
+        ...state,    
+        policyholderReplacePolicyholdercontributionplanbundleReq: false,
+        policyholderReplacePolicyholdercontributionplanbundleResp: true,
+        policyholderReplacePolicyholdercontributionplanbundleRErr: false,
+      },
+        "replacePolicyHolderContributionPlanBundle",
+        action
+      );
+    case "POLICYHOLDER_REPLACE_POLICYHOLDERCONTRIBUTIONPLANBUNDLE_ERR":
+      return dispatchMutationResp({
+        ...state,    
+        policyholderReplacePolicyholdercontributionplanbundleReq: false,
+        policyholderReplacePolicyholdercontributionplanbundleResp: false,
+        policyholderReplacePolicyholdercontributionplanbundleRErr: true,
+      },
+        "replacePolicyHolderContributionPlanBundle",
+        action
+      );
+    case "POLICYHOLDER_CREATE_POLICYHOLDERUSER_REQ":
+      return dispatchMutationResp({
+        ...state,
+        policyholderCreatePolicyholderuserReq: true,
+        policyholderCreatePolicyholderuserResp: false,
+        policyholderCreatePolicyholderuserErr: false,
+        }, "createPolicyHolderUser", action);
     case "POLICYHOLDER_CREATE_POLICYHOLDERUSER_RESP":
-      return dispatchMutationResp(state, "createPolicyHolderUser", action);
+      return dispatchMutationResp({
+        ...state,
+        policyholderCreatePolicyholderuserReq: false,
+        policyholderCreatePolicyholderuserResp: true,
+        policyholderCreatePolicyholderuserErr: false,
+        }, "createPolicyHolderUser", action);
+    case "POLICYHOLDER_CREATE_POLICYHOLDERUSER_ERR":
+      return dispatchMutationResp({
+        ...state,
+        policyholderCreatePolicyholderuserReq: false,
+        policyholderCreatePolicyholderuserResp: false,
+        policyholderCreatePolicyholderuserErr: true,
+        }, "createPolicyHolderUser", action);
+    case "POLICYHOLDER_UPDATE_POLICYHOLDERUSER_REQ":
+      return dispatchMutationResp({
+        ...state,
+        policyholderUpdatePolicyholderuserReq: true,
+        policyholderUpdatePolicyholderuserResp: false,
+        policyholderUpdatePolicyholderuserErr: false
+      }, "updatePolicyHolderUser", action);
     case "POLICYHOLDER_UPDATE_POLICYHOLDERUSER_RESP":
-      return dispatchMutationResp(state, "updatePolicyHolderUser", action);
+      return dispatchMutationResp({
+        ...state,
+        policyholderUpdatePolicyholderuserReq: false,
+        policyholderUpdatePolicyholderuserResp: true,
+        policyholderUpdatePolicyholderuserErr: false
+      }, "updatePolicyHolderUser", action);
+    case "POLICYHOLDER_UPDATE_POLICYHOLDERUSER_ERR":
+      return dispatchMutationResp({
+        ...state,
+        policyholderUpdatePolicyholderuserReq: false,
+        policyholderUpdatePolicyholderuserResp: false,
+        policyholderUpdatePolicyholderuserErr: true
+      }, "updatePolicyHolderUser", action);
+    case "POLICYHOLDER_DELETE_POLICYHOLDERUSER_REQ":
+      return dispatchMutationResp({
+        ...state,
+        policyholderDeletePolicyholderuserReq: true,
+        policyholderDeletePolicyholderuserResp: false,
+        policyholderDeletePolicyholderuserErr: false,
+      }, "deletePolicyHolderUser", action);
     case "POLICYHOLDER_DELETE_POLICYHOLDERUSER_RESP":
-      return dispatchMutationResp(state, "deletePolicyHolderUser", action);
+      return dispatchMutationResp({
+        ...state,
+        policyholderDeletePolicyholderuserReq: false,
+        policyholderDeletePolicyholderuserResp: true,
+        policyholderDeletePolicyholderuserErr: false,
+      }, "deletePolicyHolderUser", action);
+    case "POLICYHOLDER_DELETE_POLICYHOLDERUSER_ERR":
+      return dispatchMutationResp({
+        ...state,
+        policyholderDeletePolicyholderuserReq: false,
+        policyholderDeletePolicyholderuserResp: false,
+        policyholderDeletePolicyholderuserErr: true,
+      }, "deletePolicyHolderUser", action);
+    case "POLICYHOLDER_REPLACE_POLICYHOLDERUSER_REQ":
+      return dispatchMutationResp({
+        ...state,
+        policyholderReplacePolicyholderuserReq: true,
+        policyholderReplacePolicyholderuserResp: false,
+        policyholderReplacePolicyholderuserErr: false,
+      }, "replacePolicyHolderUser", action);
     case "POLICYHOLDER_REPLACE_POLICYHOLDERUSER_RESP":
-      return dispatchMutationResp(state, "replacePolicyHolderUser", action);
+      return dispatchMutationResp({
+        ...state,
+        policyholderReplacePolicyholderuserReq: false,
+        policyholderReplacePolicyholderuserResp: true,
+        policyholderReplacePolicyholderuserErr: false,
+      }, "replacePolicyHolderUser", action);
+    case "POLICYHOLDER_REPLACE_POLICYHOLDERUSER_ERR":
+      return dispatchMutationResp({
+        ...state,
+        policyholderReplacePolicyholderuserReq: false,
+        policyholderReplacePolicyholderuserResp: false,
+        policyholderReplacePolicyholderuserErr: true,
+      }, "replacePolicyHolderUser", action);
     default:
       return state;
   }


### PR DESCRIPTION
TICKET: [OP-1906](https://openimis.atlassian.net/browse/OP-1906).

The issue was due to the invalid refresh execution right after the request was sent. This didn't gave time for the mutation to finish. Same scenario was true for the PH Insuree and PH Users tabs which also were changed.  

[OP-1906]: https://openimis.atlassian.net/browse/OP-1906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ